### PR TITLE
fix: 長押しでスタート/ストップを切り替える機能の当たり判定がおかしいのを修正

### DIFF
--- a/lib/pages/index_page.dart
+++ b/lib/pages/index_page.dart
@@ -110,13 +110,13 @@ class _IndexPageState extends State<IndexPage> {
                       Column(
                         children: [
                           SizedBox(height: 32.h),
-                          Container(
-                            color: AppColors.pinpBgColor,
-                            child: GestureDetector(
-                              onLongPress: () {
-                                HapticFeedback.heavyImpact();
-                                _controller.toggle();
-                              },
+                          GestureDetector(
+                            onLongPress: () {
+                              HapticFeedback.heavyImpact();
+                              _controller.toggle();
+                            },
+                            child: Container(
+                              color: AppColors.pinpBgColor,
                               child: ConstrainedBox(
                                 constraints: BoxConstraints(
                                     maxHeight: 152.h, maxWidth: 304.w),


### PR DESCRIPTION
## 主な変更

- 長押しでスタート/ストップを切り替える機能の当たり判定がおかしいのを修正