### PR TITLE
fix: 最終使用時間をその日の 0時0分0秒に設定するようにすることで連続起動のカウントを正しく処理するように修正

### DIFF
--- a/lib/core/last_used_time.dart
+++ b/lib/core/last_used_time.dart
@@ -5,7 +5,9 @@ const _key = 'lastUsedTime';
 /// 最終使用時間を保存する
 Future<void> saveLastUsedTime() async {
   final prefs = await SharedPreferences.getInstance();
-  prefs.setInt(_key, DateTime.now().millisecondsSinceEpoch);
+  final today = DateTime.now();
+  final todayZero = DateTime(today.year, today.month, today.day);
+  prefs.setInt(_key, todayZero.millisecondsSinceEpoch);
 }
 
 /// 最終使用時間を取得


### PR DESCRIPTION
## 主な変更

- 最終使用時間をその日の 0時0分0秒に設定するようにすることで連続起動のカウントを正しく処理
するように修正